### PR TITLE
Fix API Documentation URL Construction

### DIFF
--- a/src/app/dashboardv2/header-v2/header.component.ts
+++ b/src/app/dashboardv2/header-v2/header.component.ts
@@ -326,8 +326,13 @@ export class HeaderComponent implements OnInit {
     this.httpService.getAppConfigurationDetails().subscribe(
       (response) => {
         if (response?.success) {
-          this.configDetails = response.data;
-          this.sharedService.setConfigurationDetails(response.data);
+          const data = response.data;
+          // Combine baseUrl with relative URLs
+          if (data.apiDocumentation && data.apiDocumentation.startsWith('/')) {
+            data.apiDocumentation = environment.baseUrl + data.apiDocumentation;
+          }
+          this.configDetails = data;
+          this.sharedService.setConfigurationDetails(data);
         }
       },
       (error) => {


### PR DESCRIPTION
**Problem:**
Instead of having hardcoded production API documentation URLs, the /api/config endpoint now returns relative URLs (e.g., "/swagger-ui/index.html").

**Solution:**
Modified header.component.ts to dynamically combine environment.baseUrl with relative URLs from the API response.
<img width="586" height="113" alt="image" src="https://github.com/user-attachments/assets/9c7dffc6-c658-4b67-a161-4b4a44ef1dd3" />
